### PR TITLE
Improving sending events in event broadcaster

### DIFF
--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
@@ -217,7 +217,7 @@ void EventBroadcaster::sendEvent(const InfoObjectCommon* channel, const MidiMess
         baseEvent = SpikeEvent::deserializeFromMessage(msg, static_cast<const SpikeChannel*>(channel));
         index = static_cast<SpikeEvent*>(baseEvent.get())->getSortedID();
         metaDataChannel = static_cast<const MetaDataEventObject*>(static_cast<const SpikeChannel*>(channel));
-        envelope = "spike/type:" + identifier + "/sortedID:" + String(index);
+        envelope = "spike/sortedID:" + String(index) + "/type:" + identifier;
         break;
 
     case PROCESSOR_EVENT:

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
@@ -39,6 +39,9 @@ void* EventBroadcaster::ZMQContext::createZMQSocket()
 #ifdef ZEROMQ
     jassert(context != nullptr);
     return zmq_socket(context, ZMQ_PUB);
+#else
+    jassertfalse; // should never be called in this case
+    return nullptr;
 #endif
 }
 

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
@@ -219,14 +219,14 @@ void EventBroadcaster::sendEvent(const InfoObjectCommon* channel, const MidiMess
     {
         uint16 index;
     case SPIKE_EVENT:
-        baseEvent = SpikeEvent::deserializeFromMessage(msg, static_cast<const SpikeChannel*>(channel));
+        baseEvent = SpikeEvent::deserializeFromMessage(msg, static_cast<const SpikeChannel*>(channel)).release();
         index = static_cast<SpikeEvent*>(baseEvent.get())->getSortedID();
         metaDataChannel = static_cast<const MetaDataEventObject*>(static_cast<const SpikeChannel*>(channel));
         envelope = "spike/sortedID:" + String(index) + "/type:" + identifier;
         break;
 
     case PROCESSOR_EVENT:
-        baseEvent = Event::deserializeFromMessage(msg, static_cast<const EventChannel*>(channel));
+        baseEvent = Event::deserializeFromMessage(msg, static_cast<const EventChannel*>(channel)).release();
         index = static_cast<Event*>(baseEvent.get())->getChannel();
         metaDataChannel = static_cast<const MetaDataEventObject*>(static_cast<const EventChannel*>(channel));
         envelope = "event/channel:" + String(index) + "/type:" + identifier;

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.h
@@ -67,23 +67,6 @@ private:
     int unbindZMQSocket();
     int rebindZMQSocket();
 
-    /*
-    * First part of message("envelope") is important b/c subscribers can't use any later parts for filtering.
-    * Should include information relevant for subscribers to decide whether they need this event.
-    * See: http://zguide.zeromq.org/page:all#Pub-Sub-Message-Envelopes
-    * 
-    * Structure (as a *packed* byte array, i.e. no alignment):
-    * - baseType   (uint8)        - either PROCESSOR_EVENT (1) or SPIKE_EVENT (2)).
-    * - index      (uint16)       - corresponds to TTL channel for TTL events, whatever was assigned
-    *                               to "channel" for other processor events, and the sorted ID for spikes.
-    * - identifier (utf-8 string) - the channel's "machine-readable data identifier" (no null terminator).
-    */
-    class Envelope : public MemoryBlock
-    {
-    public:
-        Envelope(uint8 baseType, uint16 index, const String& identifier);
-    };
-
 	void sendEvent(const InfoObjectCommon* channel, const MidiMessage& event) const;
     
     // returns true on success, false on failure


### PR DESCRIPTION
Let me know what you think @markschatza. There are some things that could be made prettier, maybe...

As it says in one of the comments, the "envelope" part i.e. the first packet we send is important because it lets any recipients filter out which events to continue receiving based on some prefix. I tried to put things in a logical order based on what one might want to filter by, so first whether it's a spike or other event, then the channel/spike ID, and then the event identifier. Not sure that covers all cases though.