### PR TITLE
Output raw binary, header (envelope) only, or header + JSON from Event Broadcaster

### DIFF
--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
@@ -120,6 +120,7 @@ void EventBroadcaster::reportActualListeningPort(int port)
 EventBroadcaster::EventBroadcaster()
     : GenericProcessor  ("Event Broadcaster")
     , listeningPort     (0)
+    , outputFormat      (RAW_BINARY)
 {
     setProcessorType (PROCESSOR_TYPE_SINK);
 
@@ -198,6 +199,12 @@ int EventBroadcaster::setListeningPort(int port, bool forceRestart)
 }
 
 
+void EventBroadcaster::setOutputFormat(Format newFormat)
+{
+    outputFormat = newFormat;
+}
+
+
 void EventBroadcaster::process(AudioSampleBuffer& continuousBuffer)
 {
     checkForEvents(true);
@@ -206,157 +213,204 @@ void EventBroadcaster::process(AudioSampleBuffer& continuousBuffer)
 void EventBroadcaster::sendEvent(const InfoObjectCommon* channel, const MidiMessage& msg) const
 {
 #ifdef ZEROMQ
-    void* socket = zmqSocket.get();
-
     // TODO Create a procotol that has outline for every type of event
+    Format currFormat = outputFormat;
+    Array<MsgPart> message;
 
     // common info that isn't type-specific
     EventType baseType = Event::getBaseType(msg);
     const String& identifier = channel->getIdentifier();
     float sampleRate = channel->getSampleRate();
     int64 timestamp = Event::getTimestamp(msg);
-    
-    // info to be assigned depending on the event type
-    String envelope;
-    DynamicObject::Ptr message = new DynamicObject();
-    EventBasePtr baseEvent;
-    const MetaDataEventObject* metaDataChannel;
 
-    // Add common info to JSON
-    // Still sending these guys as float/doubles for now. Might change in future.
-    DynamicObject::Ptr timing = new DynamicObject();
-    timing->setProperty("sampleRate", sampleRate);
-    timing->setProperty("timestamp", timestamp);
-    message->setProperty("timing", timing.get());
-
-    message->setProperty("identifier", identifier);
-    message->setProperty("name", channel->getName());
-    // deserialize event and get type-specific information
-    switch (baseType)
+    if (currFormat == RAW_BINARY)
     {
-    case SPIKE_EVENT:
-    {
-        auto spikeChannel = static_cast<const SpikeChannel*>(channel);
-        metaDataChannel = static_cast<const MetaDataEventObject*>(spikeChannel);
+        uint16 baseType16 = static_cast<uint16>(baseType); // for backward compatability
+        double timestampSeconds = double(timestamp) / sampleRate;
+        const void* rawData = msg.getRawData();
+        size_t rawDataSize = msg.getRawDataSize();
 
-        baseEvent = SpikeEvent::deserializeFromMessage(msg, spikeChannel).release();
-        auto spike = static_cast<SpikeEvent*>(baseEvent.get());
-
-        // create envelope
-        uint16 sortedID = spike->getSortedID();
-        envelope = "spike/sortedid:" + String(sortedID) + "/id:" + identifier + "/ts:" + String(timestamp);
-
-        // add info to JSON
-        message->setProperty("type", "spike");
-        message->setProperty("sortedID", sortedID);
-
-        int spikeChannels = spikeChannel->getNumChannels();
-        message->setProperty("numChannels", spikeChannels);
-
-        Array<var> thresholds;
-        for (int i = 0; i < spikeChannels; ++i)
-        {
-            thresholds.add(spike->getThreshold(i));
-        }
-        message->setProperty("threshold", thresholds);
-
-        break;  // case SPIKE_EVENT
+        message.add({ "base type", { &baseType16, sizeof(baseType16) } });
+        message.add({ "timestamp", { &timestampSeconds, sizeof(timestampSeconds) } });
+        message.add({ "raw data", { rawData, rawDataSize } });
     }
-
-    case PROCESSOR_EVENT:
+    else // deserialize the data, get metadata, etc.
     {
-        auto eventChannel = static_cast<const EventChannel*>(channel);
-        metaDataChannel = static_cast<const MetaDataEventObject*>(eventChannel);
+        // info to be assigned depending on the event type
+        String header;
+        DynamicObject::Ptr jsonObj = new DynamicObject();
+        EventBasePtr baseEvent;
+        const MetaDataEventObject* metaDataChannel;
 
-        baseEvent = Event::deserializeFromMessage(msg, eventChannel).release();
-        auto event = static_cast<Event*>(baseEvent.get());
-        
-        uint16 channel = event->getChannel();
-        message->setProperty("channel", channel);
-
-        auto eventType = event->getEventType();
-        switch (eventType)
+        // deserialize event and get type-specific information
+        switch (baseType)
         {
-        case EventChannel::EventChannelTypes::TTL:
+        case SPIKE_EVENT:
         {
-            bool state = static_cast<TTLEvent*>(event)->getState();
+            auto spikeChannel = static_cast<const SpikeChannel*>(channel);
+            metaDataChannel = static_cast<const MetaDataEventObject*>(spikeChannel);
 
-            envelope = "ttl/channel:" + String(channel) + "/state:" + (state ? "1" : "0") +
-                "/id:" + identifier + "/ts:" + String(timestamp);
+            baseEvent = SpikeEvent::deserializeFromMessage(msg, spikeChannel).release();
+            auto spike = static_cast<SpikeEvent*>(baseEvent.get());
 
-            message->setProperty("type", "ttl");
-            message->setProperty("data", state);
-            break;
+            // create header
+            uint16 sortedID = spike->getSortedID();
+            header = "spike/sortedid:" + String(sortedID) + "/id:" + identifier + "/ts:" + String(timestamp);
+
+            if (currFormat == HEADER_AND_JSON)
+            {
+                // add info to JSON
+                jsonObj->setProperty("type", "spike");
+                jsonObj->setProperty("sortedID", sortedID);
+
+                int spikeChannels = spikeChannel->getNumChannels();
+                jsonObj->setProperty("numChannels", spikeChannels);
+
+                Array<var> thresholds;
+                for (int i = 0; i < spikeChannels; ++i)
+                {
+                    thresholds.add(spike->getThreshold(i));
+                }
+                jsonObj->setProperty("threshold", thresholds);
+            }
+
+            break;  // case SPIKE_EVENT
         }
 
-        case EventChannel::EventChannelTypes::TEXT:
+        case PROCESSOR_EVENT:
         {
-            const String& text = static_cast<TextEvent*>(event)->getText();
+            auto eventChannel = static_cast<const EventChannel*>(channel);
+            metaDataChannel = static_cast<const MetaDataEventObject*>(eventChannel);
 
-            envelope = "text/channel:" + String(channel) + "/id:" + identifier +
-                "/text:" + text + "/ts:" + String(timestamp);
+            baseEvent = Event::deserializeFromMessage(msg, eventChannel).release();
+            auto event = static_cast<Event*>(baseEvent.get());
 
-            message->setProperty("type", "text");
-            message->setProperty("data", text);
-            break;
+            uint16 channel = event->getChannel();
+
+            // for json
+            var type;
+            var data;
+
+            auto eventType = event->getEventType();
+            switch (eventType)
+            {
+            case EventChannel::EventChannelTypes::TTL:
+            {
+                bool state = static_cast<TTLEvent*>(event)->getState();
+
+                header = "ttl/channel:" + String(channel) + "/state:" + (state ? "1" : "0") +
+                    "/id:" + identifier + "/ts:" + String(timestamp);
+
+                type = "ttl";
+                data = state;
+                break;
+            }
+
+            case EventChannel::EventChannelTypes::TEXT:
+            {
+                const String& text = static_cast<TextEvent*>(event)->getText();
+
+                header = "text/channel:" + String(channel) + "/id:" + identifier +
+                    "/text:" + text + "/ts:" + String(timestamp);
+
+                type = "text";
+                data = text;
+                break;
+            }
+
+            default:
+            {
+                if (eventType < EventChannel::EventChannelTypes::BINARY_BASE_VALUE ||
+                    eventType >= EventChannel::EventChannelTypes::INVALID)
+                {
+                    jassertfalse;
+                    return;
+                }
+
+                // must have binary event
+
+                BaseType dataType = eventChannel->getEquivalentMetaDataType();
+                const void* rawData = static_cast<BinaryEvent*>(event)->getBinaryDataPointer();
+                unsigned int length = eventChannel->getLength();
+
+                auto dataReader = getDataReader(dataType);
+                if (!dataReader) // invalid type?
+                {
+                    jassertfalse;
+                    return;
+                }
+
+                type = "binary";
+                data = dataReader(rawData, length);
+
+                header = "binary/channel:" + String(channel) + "/id:" + identifier +
+                    "/data:" + data.toString() + "/ts:" + String(timestamp);
+
+                break;
+            }
+            } // end switch(eventType)
+
+            if (currFormat == HEADER_AND_JSON)
+            {
+                jsonObj->setProperty("channel", channel);
+                jsonObj->setProperty("type", type);
+                jsonObj->setProperty("data", data);
+            }
+
+            break; // case PROCESSOR_EVENT
         }
 
         default:
+            jassertfalse; // should never happen
+            return;
+
+        } // end switch(baseType)
+
+        message.add({ "header", { header.toRawUTF8(), header.getNumBytesAsUTF8() } });
+
+        String jsonString; // must be outside the if-statement so it remains in scope when we send the message
+        if (currFormat == HEADER_AND_JSON)
         {
-            if (eventType < EventChannel::EventChannelTypes::BINARY_BASE_VALUE ||
-                eventType >= EventChannel::EventChannelTypes::INVALID)
-            {
-                jassertfalse;
-                return;
-            }
+            // Add common info to JSON
+            // Still sending these guys as float/doubles for now. Might change in future.
+            DynamicObject::Ptr timing = new DynamicObject();
+            timing->setProperty("sampleRate", sampleRate);
+            timing->setProperty("timestamp", timestamp);
+            jsonObj->setProperty("timing", timing.get());
 
-            // must have binary event
+            jsonObj->setProperty("identifier", identifier);
+            jsonObj->setProperty("name", channel->getName());
 
-            envelope = "binary/channel:" + String(channel) + "/id:" + identifier +
-                "/ts:" + String(timestamp);
+            // Add metadata
+            DynamicObject::Ptr metaDataObj = new DynamicObject();
+            populateMetaData(metaDataChannel, baseEvent, metaDataObj);
+            jsonObj->setProperty("metaData", metaDataObj.get());
 
-            message->setProperty("type", "binary");
-
-            BaseType dataType = eventChannel->getEquivalentMetaDataType();
-            const void* rawData = static_cast<BinaryEvent*>(event)->getBinaryDataPointer();
-            unsigned int length = eventChannel->getLength();
-
-            auto dataReader = getDataReader(dataType);
-            if (!dataReader) // invalid type?
-            {
-                jassertfalse;
-                return;
-            }
-            message->setProperty("data", dataReader(rawData, length));
-            break;
+            String jsonString = JSON::toString(var(jsonObj));
+            message.add({ "json", { jsonString.toRawUTF8(), jsonString.getNumBytesAsUTF8() } });
         }
-        } // end switch(eventType)
-
-        break; // case PROCESSOR_EVENT
     }
 
-    default:
-        jassertfalse; // should never happen
-        return;
+    sendMessage(message);
+#endif
+}
 
-    } // end switch(baseType)
-
-    // Add metadata
-    DynamicObject::Ptr metaDataObj = new DynamicObject();
-    populateMetaData(metaDataChannel, baseEvent, metaDataObj);
-    message->setProperty("metaData", metaDataObj.get());
-
-    // Finally, send everything
-    var jsonMes(message);
-    String tempStr = JSON::toString(jsonMes);
-    const char* jsonStr = tempStr.toUTF8();
-    std::cout << jsonStr << std::endl;
-    const char* envelopeStr = envelope.toUTF8();
-    if (!sendPackage(socket, envelopeStr, jsonStr))
+int EventBroadcaster::sendMessage(const Array<MsgPart>& parts) const
+{
+#ifdef ZEROMQ
+    int numParts = parts.size();
+    for (int i = 0; i < numParts; ++i)
     {
-        std::cout << "Error sending Package" << std::endl;
+        const MsgPart& part = parts.getUnchecked(i);
+        int flags = (i < numParts - 1) ? ZMQ_SNDMORE : 0;
+        if (-1 == zmq_send(zmqSocket.get(), part.data.getData(), part.data.getSize(), flags))
+        {
+            std::cout << "Error sending " << part.name << ": " << zmq_strerror(zmq_errno()) << std::endl;
+            return -1;
+        }
     }
 #endif
+    return 0;
 }
 
 void EventBroadcaster::populateMetaData(const MetaDataEventObject* channel,
@@ -385,27 +439,6 @@ void EventBroadcaster::populateMetaData(const MetaDataEventObject* channel,
     }
 }
 
-bool EventBroadcaster::sendPackage(void* socket, const char* envelopeStr, const char* jsonStr)
-{
-    
-#ifdef ZEROMQ
-    if (-1 == zmq_send(socket, envelopeStr, strlen(envelopeStr), ZMQ_SNDMORE))
-    {
-        std::cout << "Error sending envelope: " << zmq_strerror(zmq_errno()) << std::endl;
-        return false;
-    }
-
-    if (-1 == zmq_send(socket, jsonStr, strlen(jsonStr), 0))
-    {
-        std::cout << "Error sending json: " << zmq_strerror(zmq_errno()) << std::endl;
-        return false;
-    }
-    return true;
-#else
-    std::cout << "No ZEROMQ" << std::endl;
-    return false;
-#endif
-}
 
 void EventBroadcaster::handleEvent(const EventChannel* channelInfo, const MidiMessage& event, int samplePosition)
 {
@@ -450,7 +483,7 @@ var EventBroadcaster::binaryValueToVar(const void* value, unsigned int dataLengt
     else
     {
         Array<var> metaDataArray;
-        for (int i = 0; i < dataLength; ++i)
+        for (unsigned int i = 0; i < dataLength; ++i)
         {
             metaDataArray.add(String(typedValue[i]));
         }

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
@@ -140,12 +140,6 @@ AudioProcessorEditor* EventBroadcaster::createEditor()
 }
 
 
-int EventBroadcaster::getListeningPort() const
-{
-    return listeningPort;
-}
-
-
 int EventBroadcaster::setListeningPort(int port, bool forceRestart)
 {
     if (listeningPort == port && !forceRestart)
@@ -199,12 +193,6 @@ int EventBroadcaster::setListeningPort(int port, bool forceRestart)
 }
 
 
-void EventBroadcaster::setOutputFormat(Format newFormat)
-{
-    outputFormat = newFormat;
-}
-
-
 void EventBroadcaster::process(AudioSampleBuffer& continuousBuffer)
 {
     checkForEvents(true);
@@ -214,7 +202,7 @@ void EventBroadcaster::sendEvent(const InfoObjectCommon* channel, const MidiMess
 {
 #ifdef ZEROMQ
     // TODO Create a procotol that has outline for every type of event
-    Format currFormat = outputFormat;
+    int currFormat = outputFormat;
     Array<MsgPart> message;
 
     // common info that isn't type-specific
@@ -454,6 +442,7 @@ void EventBroadcaster::saveCustomParametersToXml(XmlElement* parentElement)
 {
     XmlElement* mainNode = parentElement->createNewChildElement("EVENTBROADCASTER");
     mainNode->setAttribute("port", listeningPort);
+    mainNode->setAttribute("format", outputFormat);
 }
 
 
@@ -465,7 +454,14 @@ void EventBroadcaster::loadCustomParametersFromXml()
         {
             if (mainNode->hasTagName("EVENTBROADCASTER"))
             {
-                setListeningPort(mainNode->getIntAttribute("port"));
+                setListeningPort(mainNode->getIntAttribute("port", listeningPort));
+
+                outputFormat = mainNode->getIntAttribute("format", outputFormat);
+                auto ed = static_cast<EventBroadcasterEditor*>(getEditor());
+                if (ed)
+                {
+                    ed->setDisplayedFormat(outputFormat);
+                }
             }
         }
     }

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
@@ -139,6 +139,12 @@ AudioProcessorEditor* EventBroadcaster::createEditor()
 }
 
 
+int EventBroadcaster::getListeningPort() const
+{
+    return listeningPort;
+}
+
+
 int EventBroadcaster::setListeningPort(int port, bool forceRestart)
 {
     if (listeningPort == port && !forceRestart)
@@ -189,6 +195,18 @@ int EventBroadcaster::setListeningPort(int port, bool forceRestart)
     reportActualListeningPort(port);
     return 0;
 #endif
+}
+
+
+int EventBroadcaster::getOutputFormat() const
+{
+    return outputFormat;
+}
+
+
+void EventBroadcaster::setOutputFormat(int format)
+{
+    outputFormat = format;
 }
 
 

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.h
@@ -26,7 +26,6 @@
 
 class EventBroadcaster : public GenericProcessor
 {
-    friend class EventBroadcasterEditor;
 public:
     // ids for format combobox
     enum Format { RAW_BINARY = 1, HEADER_ONLY, HEADER_AND_JSON };
@@ -35,8 +34,12 @@ public:
 
     AudioProcessorEditor* createEditor() override;
 
+    int getListeningPort() const;
     // returns 0 on success, else the errno value for the error that occurred.
     int setListeningPort (int port, bool forceRestart = false);
+
+    int getOutputFormat() const;
+    void setOutputFormat(int format);
 
     void process(AudioSampleBuffer& continuousBuffer) override;
     void handleEvent(const EventChannel* channelInfo, const MidiMessage& event, int samplePosition = 0) override;
@@ -86,7 +89,7 @@ private:
 
     static String getEndpoint(int port);
 
-    // called from getListeningPort() depending on success/failure of ZMQ operations
+    // called from setListeningPort() depending on success/failure of ZMQ operations
     void reportActualListeningPort(int port);
 
     // share a "dumb" pointer that doesn't take part in reference counting.

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.h
@@ -12,8 +12,6 @@
 #define EVENTBROADCASTER_H_INCLUDED
 
 #include <ProcessorHeaders.h>
-//#include "json.h"
-//#include "json-forwards.h"
 
 #ifdef ZEROMQ
     #ifdef WIN32
@@ -85,8 +83,6 @@ private:
     // add metadata from an event to a DynamicObject
     static void populateMetaData(const MetaDataEventObject* channel,
         const EventBasePtr event, DynamicObject::Ptr dest);
-
-    static void sendRaw(void* socket, EventType baseType, double tsSec, void* data, int dataSize);
 
     static String getEndpoint(int port);
 

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.h
@@ -28,17 +28,17 @@
 
 class EventBroadcaster : public GenericProcessor
 {
+    friend class EventBroadcasterEditor;
 public:
+    // ids for format combobox
+    enum Format { RAW_BINARY = 1, HEADER_ONLY, HEADER_AND_JSON };
+
     EventBroadcaster();
 
     AudioProcessorEditor* createEditor() override;
 
-    int getListeningPort() const;
     // returns 0 on success, else the errno value for the error that occurred.
     int setListeningPort (int port, bool forceRestart = false);
-
-    enum Format { RAW_BINARY, HEADER_ONLY, HEADER_AND_JSON };
-    void setOutputFormat(Format newFormat);
 
     void process(AudioSampleBuffer& continuousBuffer) override;
     void handleEvent(const EventChannel* channelInfo, const MidiMessage& event, int samplePosition = 0) override;
@@ -101,7 +101,7 @@ private:
     ZMQSocketPtr zmqSocket;
     int listeningPort;
 
-    Format outputFormat;
+    int outputFormat;
 
     // ---- utilities for formatting binary data and metadata ----
     

--- a/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.cpp
@@ -29,7 +29,7 @@ EventBroadcasterEditor::EventBroadcasterEditor(GenericProcessor* parentNode, boo
     urlLabel->setBounds(20, 60, 140, 25);
     addAndMakeVisible(urlLabel);
 
-    portLabel = new Label("Port", String(p->listeningPort));
+    portLabel = new Label("Port", String(p->getListeningPort()));
     portLabel->setBounds(70,65,80,18);
     portLabel->setFont(Font("Default", 15, Font::plain));
     portLabel->setColour(Label::textColourId, Colours::white);
@@ -47,7 +47,7 @@ EventBroadcasterEditor::EventBroadcasterEditor(GenericProcessor* parentNode, boo
     formatBox->addItem("Raw binary", EventBroadcaster::Format::RAW_BINARY);
     formatBox->addItem("Header only", EventBroadcaster::Format::HEADER_ONLY);
     formatBox->addItem("Header/JSON", EventBroadcaster::Format::HEADER_AND_JSON);
-    formatBox->setSelectedId(p->outputFormat);
+    formatBox->setSelectedId(p->getOutputFormat());
     formatBox->addListener(this);
     addAndMakeVisible(formatBox);
 
@@ -60,7 +60,7 @@ void EventBroadcasterEditor::buttonEvent(Button* button)
     if (button == restartConnection)
     {
         EventBroadcaster* p = (EventBroadcaster*)getProcessor();
-        int status = p->setListeningPort(p->listeningPort, true);
+        int status = p->setListeningPort(p->getListeningPort(), true);
 
 #ifdef ZEROMQ
         if (status != 0)
@@ -96,7 +96,7 @@ void EventBroadcasterEditor::comboBoxChanged(ComboBox* comboBoxThatHasChanged)
     if (comboBoxThatHasChanged == formatBox)
     {
         auto p = static_cast<EventBroadcaster*>(getProcessor());
-        p->outputFormat = comboBoxThatHasChanged->getSelectedId();
+        p->setOutputFormat(comboBoxThatHasChanged->getSelectedId());
     }
 }
 

--- a/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.cpp
@@ -18,24 +18,38 @@ EventBroadcasterEditor::EventBroadcasterEditor(GenericProcessor* parentNode, boo
 {
     desiredWidth = 180;
 
-    urlLabel = new Label("Port", "Port:");
-    urlLabel->setBounds(20,80,140,25);
-    addAndMakeVisible(urlLabel);
     EventBroadcaster* p = (EventBroadcaster*)getProcessor();
 
     restartConnection = new UtilityButton("Restart Connection",Font("Default", 15, Font::plain));
-    restartConnection->setBounds(20,45,150,18);
+    restartConnection->setBounds(10,35,150,18);
     restartConnection->addListener(this);
     addAndMakeVisible(restartConnection);
 
-    portLabel = new Label("Port", String(p->getListeningPort()));
-    portLabel->setBounds(70,85,80,18);
+    urlLabel = new Label("Port", "Port:");
+    urlLabel->setBounds(20, 60, 140, 25);
+    addAndMakeVisible(urlLabel);
+
+    portLabel = new Label("Port", String(p->listeningPort));
+    portLabel->setBounds(70,65,80,18);
     portLabel->setFont(Font("Default", 15, Font::plain));
     portLabel->setColour(Label::textColourId, Colours::white);
     portLabel->setColour(Label::backgroundColourId, Colours::grey);
     portLabel->setEditable(true);
     portLabel->addListener(this);
     addAndMakeVisible(portLabel);
+
+    formatLabel = new Label("Format", "Format:");
+    formatLabel->setBounds(5, 100, 60, 25);
+    addAndMakeVisible(formatLabel);
+
+    formatBox = new ComboBox("FormatBox");
+    formatBox->setBounds(65, 100, 100, 20);
+    formatBox->addItem("Raw binary", EventBroadcaster::Format::RAW_BINARY);
+    formatBox->addItem("Header only", EventBroadcaster::Format::HEADER_ONLY);
+    formatBox->addItem("Header/JSON", EventBroadcaster::Format::HEADER_AND_JSON);
+    formatBox->setSelectedId(p->outputFormat);
+    formatBox->addListener(this);
+    addAndMakeVisible(formatBox);
 
     setEnabledState(false);
 }
@@ -46,7 +60,7 @@ void EventBroadcasterEditor::buttonEvent(Button* button)
     if (button == restartConnection)
     {
         EventBroadcaster* p = (EventBroadcaster*)getProcessor();
-        int status = p->setListeningPort(p->getListeningPort(), true);
+        int status = p->setListeningPort(p->listeningPort, true);
 
 #ifdef ZEROMQ
         if (status != 0)
@@ -76,7 +90,24 @@ void EventBroadcasterEditor::labelTextChanged(juce::Label* label)
     }
 }
 
+
+void EventBroadcasterEditor::comboBoxChanged(ComboBox* comboBoxThatHasChanged)
+{
+    if (comboBoxThatHasChanged == formatBox)
+    {
+        auto p = static_cast<EventBroadcaster*>(getProcessor());
+        p->outputFormat = comboBoxThatHasChanged->getSelectedId();
+    }
+}
+
+
 void EventBroadcasterEditor::setDisplayedPort(int port)
 {
     portLabel->setText(String(port), dontSendNotification);
+}
+
+
+void EventBroadcasterEditor::setDisplayedFormat(int format)
+{
+    formatBox->setSelectedId(format, dontSendNotification);
 }

--- a/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.h
@@ -22,20 +22,27 @@
 
  */
 
-class EventBroadcasterEditor : public GenericEditor, public Label::Listener
+class EventBroadcasterEditor 
+    : public GenericEditor
+    , public Label::Listener
+    , public ComboBox::Listener
 {
 public:
     EventBroadcasterEditor(GenericProcessor* parentNode, bool useDefaultParameterEditors);
 
     void buttonEvent(Button* button) override;
     void labelTextChanged(juce::Label* label) override;
+    void comboBoxChanged(ComboBox* comboBoxThatHasChanged) override;
 
     void setDisplayedPort(int port);
+    void setDisplayedFormat(int id);
 
 private:
     ScopedPointer<UtilityButton> restartConnection;
     ScopedPointer<Label> urlLabel;
     ScopedPointer<Label> portLabel;
+    ScopedPointer<Label> formatLabel;
+    ScopedPointer<ComboBox> formatBox;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EventBroadcasterEditor);
 


### PR DESCRIPTION
Hey Mark,

Take a look and let me know if you think this way of doing things looks good. I tried to make the `sendMessage` function amenable to modifying or adding new data formats in the future.

Also sorry this took longer than I expected...I had the idea of getting rid of `unique_ptr` and using a `ScopedPointer` for the socket instead, like in Network Events, but that led to a lot of extra changes, and then I found a bug related to the socket (both versions) that I'd have to fix in another branch anyway. So I split them apart very painfully and learned a lesson about keeping branches focused on one thing at a a time.