### PR TITLE
Change setting PYTHONHOME and PYTHONPATH to actually work with Anaconda

### DIFF
--- a/Builds/VisualStudio2013/Plugins/Python/PythonEnv.props
+++ b/Builds/VisualStudio2013/Plugins/Python/PythonEnv.props
@@ -2,27 +2,22 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <PYTHONHOME_DEFAULT>$(USERPROFILE)\Anaconda3</PYTHONHOME_DEFAULT>
-    <PYTHONHOME Condition="'$(PYTHONHOME)' == ''">$(PYTHONHOME_DEFAULT)</PYTHONHOME>
+    <PYTHON_HOME Condition="'$(CONDA_HOME)' == ''">$(USERPROFILE)\Anaconda3</PYTHON_HOME>
+    <PYTHON_HOME Condition="'$(CONDA_HOME)' != ''">$(CONDA_HOME)</PYTHON_HOME>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(PYTHONHOME)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>PYTHONHOME_DEFAULT=R"?($(PYTHONHOME_DEFAULT))?";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(PYTHON_HOME)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PYTHON_HOME_NAME=R"?($(PYTHON_HOME))?";%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(PYTHONHOME)\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(PYTHON_HOME)\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>python36.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy /Y "$(PYTHONHOME)\python36.dll" "$(GUIDir)"
+      <Command>copy /Y "$(PYTHON_HOME)\python36.dll" "$(GUIDir)"
 %(Command)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <BuildMacro Include="PYTHONHOME">
-      <Value>$(PYTHONHOME)</Value>
-    </BuildMacro>
-  </ItemGroup>
 </Project>

--- a/Source/Plugins/PythonPlugin/PythonPlugin.cpp
+++ b/Source/Plugins/PythonPlugin/PythonPlugin.cpp
@@ -69,29 +69,34 @@ PythonPlugin::PythonPlugin(const String &processorName)
     filePath = "";
     plugin = 0;
 
+    // if on windows, PYTHON_HOME_NAME is set by PythonEnv.props (corresponds to CONDA_HOME environment variable)
+#ifndef _WIN32
+#define QUOTE(name) #name
+#define STR(macro) QUOTE(macro)
+#define PYTHON_HOME_NAME STR(PYTHON_HOME)
+#endif
+
     char * old_python_home = getenv("PYTHONHOME");
-    if (old_python_home == NULL)
+    if (old_python_home == NULL || strcmp(old_python_home, PYTHON_HOME_NAME) != 0)
     {
 #ifdef PYTHON_DEBUG
         std::cout << "setting PYTHONHOME" << std::endl;
 #endif
 
 #ifdef _WIN32
-        _putenv_s("PYTHONHOME", "C:\\Users\\Ephys\\Anaconda3"); // set to default PYTHONHOME by PythonEnv.props
+        _putenv_s("PYTHONHOME", PYTHON_HOME_NAME);
 #else
-#define QUOTE(name) #name
-#define STR(macro) QUOTE(macro)
-#define PYTHON_HOME_NAME STR(PYTHON_HOME)
-
-        //setenv("PYTHONHOME", "/anaconda3/bin/", 1); // FIXME hardcoded PYTHONHOME!
         setenv("PYTHONHOME", PYTHON_HOME_NAME, 1);
-        //setenv("PYTHONHOME", "/anaconda3/bin/python.app", 1); // FIXME hardcoded PYTHONHOME!
 #endif
     }
-    // setenv("PYTHONHOME", "/usr/local/anaconda", 1); // FIXME hardcoded PYTHONHOME!
 
 #ifdef PYTHON_DEBUG
     std::cout << "PYTHONHOME: " << getenv("PYTHONHOME") << std::endl;
+#endif
+
+#ifdef _WIN32
+    // set PYTHONPATH to avoid error described here: https://stackoverflow.com/questions/5694706/py-initialize-fails-unable-to-load-the-file-system-codec
+    _putenv_s("PYTHONPATH", PYTHON_HOME_NAME "\\DLLs;" PYTHON_HOME_NAME "\\Lib;" PYTHON_HOME_NAME "\\Lib\\site-packages");
 #endif
     
 #ifdef PYTHON_DEBUG
@@ -112,8 +117,6 @@ PythonPlugin::PythonPlugin(const String &processorName)
 #else
     Py_SetProgramName ((char *)"PythonPlugin");
 #endif
-    //Py_SetPythonHome("Users/ClaytonBarnes/Anaconda3");
-    //Py_SetPath("Users/ClaytonBarnes/Anaconda3/lib");
     Py_Initialize ();
     PyEval_InitThreads();
 


### PR DESCRIPTION
Hey, here's what I finally got to work for setting `PYTHONHOME` etc. The new workflow is to change the `CONDA_HOME` environment variable to point to the correct environment root if not using the base environment. (I had to restart Visual Studio and then use Project > Rescan Solution to get the `PYTHON_HOME_NAME` macro to update after changing this variable.) I've confirmed that it works with vanilla Python as well as Anaconda. We could call it something other than `CONDA_HOME` to be more agnostic to the distribution, but this way matches how the Linux Makefile works.

I figured out what was causing the weird error at runtime. It wasn't fixed by reinstalling Anaconda with the "add to PATH" option checked; what solved it was setting the `PYTHONPATH` environment variable as shown on line 99. We could also change this to append these paths onto the existing `PYTHONPATH`, if any, if that would be useful or necessary.

Not related to this PR, but after I got it working, I tried to replicate that error you were having in `handleSpike`, but it worked for me.... let's talk about it next week!