### PR TITLE
Cleaner in-place transforms and some other stuff

### DIFF
--- a/Resources/windows-libs/FFTW/include/FFTWWrapper.h
+++ b/Resources/windows-libs/FFTW/include/FFTWWrapper.h
@@ -32,6 +32,7 @@ transform library
 #include <JuceHeader.h> // assertions, etc.
 #include <complex>
 #include <algorithm>    // reverse array
+#include <utility>
 
 #include "fftw3.h" // Fast Fourier Transform library
 
@@ -54,7 +55,8 @@ public:
         fftw_free(data);
     }
 
-    void resize(int newLength)
+    // returns true if a resize actually occurred
+    virtual bool resize(int newLength)
     {
         jassert(newLength >= 0);
         if (newLength != length)
@@ -62,7 +64,9 @@ public:
             length = newLength;
             fftw_free(data);
             data = reinterpret_cast<std::complex<double>*>(fftw_alloc_complex(newLength));
+            return true;
         }
+        return false;
     }
 
     std::complex<double> getAsComplex(int i)
@@ -104,7 +108,7 @@ public:
         return nullptr;
     }
 
-    int getLength()
+    int getLength() const
     {
         return length;
     }
@@ -167,15 +171,40 @@ public:
         return numToCopy;
     }
 
+    FFTWArray(const FFTWArray& other)
+        : FFTWArray(other.length)
+    {
+        // delegate to copy assignment
+        *this = other;
+    }
+
     // Move to new FFTWArray. Needed to store in an array
     FFTWArray(FFTWArray&& other)
-        : data(nullptr)
-        , length(0)
     {
-        data = other.data;
-        length = other.length;
-        other.data = nullptr;
-        other.length = 0;
+        // delegate to move assignment
+        *this = std::move(other);
+    }
+
+    FFTWArray& operator=(const FFTWArray& other)
+    {
+        if (this != &other)
+        {
+            resize(other.length);
+            copyFrom(other.data, other.length);
+        }
+        return *this;
+    }
+
+    FFTWArray& operator=(FFTWArray&& other)
+    {
+        if (this != &other)
+        {
+            data = other.data;
+            length = other.length;
+            other.data = nullptr;
+            other.length = 0;
+        }
+        return *this;
     }
 
     
@@ -183,7 +212,7 @@ private:
     std::complex<double>* data;
     int length;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FFTWArray);
+    JUCE_LEAK_DETECTOR(FFTWArray);
 };
 
 class FFTWPlan
@@ -229,7 +258,136 @@ public:
 private:
     fftw_plan plan;
     const int length;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FFTWPlan);
+};
+
+
+// copyable, movable array that can do an in-place transform
+template <unsigned int flags = FFTW_MEASURE> 
+class FFTWTransformableArray : public FFTWArray
+{
+public:
+    FFTWTransformableArray(int n = 0)
+        : FFTWArray     (0)
+    {
+        resize(n);
+    }
+
+    FFTWTransformableArray(const FFTWTransformableArray& other)
+        : FFTWTransformableArray(other.getLength())
+    {
+        // delegate to copy assignment
+        *this = other;
+    }
+
+    FFTWTransformableArray(FFTWTransformableArray&& other)
+    {
+        // delegate to move assignment
+        *this = std::move(other);
+    }
+
+    FFTWTransformableArray& operator=(const FFTWTransformableArray& other)
+    {
+        if (this != &other)
+        {
+            FFTWArray::operator=(other);
+            // the plans will be copied if/when the overridden "resize" is called
+        }
+        return *this;
+    }
+
+    FFTWTransformableArray& operator=(FFTWTransformableArray&& other)
+    {
+        if (this != &other)
+        {
+            forwardPlan = other.forwardPlan;
+            inversePlan = other.inversePlan;
+            r2cPlan = other.r2cPlan;
+            FFTWArray::operator=(std::move(other));
+        }
+        return *this;
+    }
+
+    bool resize(int newLength) override
+    {
+        if (FFTWArray::resize(newLength))
+        {
+            forwardPlan = newLength > 0 ? new FFTWPlan(newLength, this, FFTW_FORWARD, flags) : nullptr;
+            inversePlan = newLength > 0 ? new FFTWPlan(newLength, this, FFTW_BACKWARD, flags) : nullptr;
+            r2cPlan = newLength > 0 ? new FFTWPlan(newLength, this, flags) : nullptr;
+            return true;
+        }
+        return false;
+    }
+
+    void fftComplex()
+    {
+        if (forwardPlan != nullptr)
+        {
+            forwardPlan->execute();
+        }
+    }
+
+    void fftReal()
+    {
+        if (r2cPlan != nullptr)
+        {
+            r2cPlan->execute();
+        }
+    }
+
+    void ifft()
+    {
+        if (inversePlan != nullptr)
+        {
+            inversePlan->execute();
+        }
+    }
+
+    // Do Hilbert transform of real data by taking the fft, zeroing out negative frequencies,
+    // and taking the ifft. The result is not technically the Hilbert transform but the
+    // analytic signal, defined as x + H[x]*i. This is consistent with Matlab's 'hilbert'.
+    void hilbert()
+    {
+        int n = getLength();
+
+        // enter the frequency domain
+        fftReal();
+
+        // normalize DC and Nyquist, normalize and double positive freqs, and set negative freqs to 0.
+        int lastPosFreq = (n + 1) / 2 - 1;
+        int firstNegFreq = n / 2 + 1;
+        int numPosNegFreqDoubles = lastPosFreq * 2; // sizeof(complex<double>) = 2 * sizeof(double)
+        bool hasNyquist = (n % 2 == 0);
+
+        std::complex<double>* wp = getComplexPointer();
+
+        // normalize but don't double DC value
+        wp[0] /= n;
+
+        // normalize and double positive frequencies
+        FloatVectorOperations::multiply(reinterpret_cast<double*>(wp + 1), 2.0 / n, numPosNegFreqDoubles);
+
+        if (hasNyquist)
+        {
+            // normalize but don't double Nyquist frequency
+            wp[lastPosFreq + 1] /= n;
+        }
+
+        // set negative frequencies to 0
+        FloatVectorOperations::clear(reinterpret_cast<double*>(wp + firstNegFreq), numPosNegFreqDoubles);
+
+        // finally IFFT to get back to time domain
+        ifft();
+    }
+
+private:
+    ScopedPointer<FFTWPlan> forwardPlan;
+    ScopedPointer<FFTWPlan> inversePlan;
+    ScopedPointer<FFTWPlan> r2cPlan;
+
+    JUCE_LEAK_DETECTOR(FFTWTransformableArray<flags>);
 };
 
 #endif // FFTW_WRAPPER_H_INCLUDED

--- a/Source/Plugins/CoherenceViewer/CoherenceNode.cpp
+++ b/Source/Plugins/CoherenceViewer/CoherenceNode.cpp
@@ -96,7 +96,7 @@ void CoherenceNode::process(AudioSampleBuffer& continuousBuffer)
         // Add to buffer the new samples.
         for (int n = 0; n < nSamples; n++)
         {
-            dataWriter->getReference(activeChan).set(n, rpIn[n]);
+            dataWriter->getReference(activeChan).set(nSamplesAdded + n, rpIn[n]);
         }  
     }
 

--- a/Source/Plugins/CoherenceViewer/CoherenceNode.cpp
+++ b/Source/Plugins/CoherenceViewer/CoherenceNode.cpp
@@ -55,7 +55,7 @@ AudioProcessorEditor* CoherenceNode::createEditor()
 
 void CoherenceNode::process(AudioSampleBuffer& continuousBuffer)
 {  
-    AtomicScopedWritePtr<Array<FFTWArray>> dataWriter(dataBuffer);
+    AtomicScopedWritePtr<Array<FFTWArrayType>> dataWriter(dataBuffer);
     //AtomicScopedReadPtr<std::vector<std::vector<double>>> coherenceReader(meanCoherence);
     //// Get current coherence vector ////
     //if (meanCoherence.hasUpdate())
@@ -68,7 +68,7 @@ void CoherenceNode::process(AudioSampleBuffer& continuousBuffer)
     // Check writer
     if (!dataWriter.isValid())
     {
-        jassert("atomic sync data writer broken");
+        jassertfalse; // atomic sync data writer broken
     }
 
     //for loop over active channels and update buffer with new data
@@ -114,7 +114,7 @@ void CoherenceNode::process(AudioSampleBuffer& continuousBuffer)
 
 void CoherenceNode::run()
 {  
-    AtomicScopedReadPtr<Array<FFTWArray>> dataReader(dataBuffer);
+    AtomicScopedReadPtr<Array<FFTWArrayType>> dataReader(dataBuffer);
     AtomicScopedWritePtr<std::vector<std::vector<double>>> coherenceWriter(meanCoherence);
     
     while (!threadShouldExit())
@@ -133,19 +133,19 @@ void CoherenceNode::run()
                 int groupNum = getChanGroup(chan);
                 if (groupNum != -1)
                 {
-                    TFR->addTrial(dataReader->getReference(activeChan).getReadPointer(activeChan), chan);
+                    TFR->addTrial(dataReader->getReference(activeChan), chan);
                 }
                 else
                 {
                     // channel isn't part of group 1 or 2
-                    jassert("ungrouped channel");
+                    jassertfalse; // ungrouped channel
                 }
             }
 
             //// Get and send updated coherence  ////
             if (!coherenceWriter.isValid())
             {
-                jassert("atomic sync coherence writer broken");
+                jassertfalse; // atomic sync coherence writer broken
             }
 
             // Calc coherence at each combination of interest
@@ -177,24 +177,13 @@ void CoherenceNode::updateDataBufferSize(int newSize)
 
     // no writers or readers can exist here
     // so this can't be called during acquisition
-    dataBuffer.map([=](Array<FFTWArray>& arr)
+    dataBuffer.map([=](Array<FFTWArrayType>& arr)
     {
-        for (int i = 0; i < jmin(totalChans, arr.size()); i++)
+        arr.resize(totalChans);
+
+        for (int i = 0; i < totalChans; i++)
         {
             arr.getReference(i).resize(newSize);
-        }
-
-        int nChansChange = totalChans - arr.size();
-        if (nChansChange > 0)
-        {
-            for (int i = 0; i < nChansChange; i++)
-            {
-                arr.add(FFTWArray(newSize));
-            }
-        }
-        else if (nChansChange < 0)
-        {
-            arr.removeLast(-nChansChange);
         }
     });
 }

--- a/Source/Plugins/CoherenceViewer/CoherenceNode.h
+++ b/Source/Plugins/CoherenceViewer/CoherenceNode.h
@@ -85,7 +85,7 @@ public:
 
 private:
 
-    AtomicallyShared<Array<FFTWArray>> dataBuffer;
+    AtomicallyShared<Array<FFTWArrayType>> dataBuffer;
     // # Freqs x # Combinations
     AtomicallyShared<std::vector<std::vector<double>>> meanCoherence;
 

--- a/Source/Plugins/CoherenceViewer/CumulativeTFR.cpp
+++ b/Source/Plugins/CoherenceViewer/CumulativeTFR.cpp
@@ -31,12 +31,7 @@ CumulativeTFR::CumulativeTFR(int ng1, int ng2, int nf, int nt, int Fs, int winLe
     , stepLen       (stepLen)
     , nTimes        (nt)
     , nfft          (int(fftSec * Fs))
-    , fftInput      (nfft)
-    , fftOutput     (nfft)
-    , ifftInput     (nfft)
-    , ifftOutput    (nfft)
-    , fftPlan(nfft, &fftInput, &fftOutput, FFTW_FORWARD, FFTW_ESTIMATE)
-    , ifftPlan(nfft, &ifftInput, &ifftOutput, FFTW_BACKWARD, FFTW_ESTIMATE)
+    , ifftBuffer    (nfft)
     , alpha         (alpha)
     , pxys          (ng1 * ng2,
                     vector<vector<ComplexWeightedAccum>>(nf,
@@ -59,16 +54,14 @@ CumulativeTFR::CumulativeTFR(int ng1, int ng2, int nf, int nt, int Fs, int winLe
     trimTime = windowLen / 2;
 }
 
-void CumulativeTFR::addTrial(const double* fftIn, int chan)
+void CumulativeTFR::addTrial(FFTWArrayType& fftBuffer, int chan)
 {
     float winsPerSegment = (segmentLen - windowLen) / stepLen;
     
     //// Update convInput ////
-    // copy dataBuffer input to fft input
-    fftInput.copyFrom(fftIn, nfft);
 
     //// Execute fft ////
-    fftPlan.execute();
+    fftBuffer.fftReal();
     float nWindow = Fs * windowLen;
     //// Use freqData to find generate spectrum and get power ////
 	for (int freq = 0; freq < nFreqs; freq++)
@@ -76,16 +69,16 @@ void CumulativeTFR::addTrial(const double* fftIn, int chan)
 		// Multiple fft data by wavelet
 		for (int n = 0; n < nfft; n++)
 		{
-            ifftInput.set(n, fftOutput.getAsComplex(n) * waveletArray[freq][n] ); // Divide by 2 so we don't go over double limits later..
+            ifftBuffer.set(n, fftBuffer.getAsComplex(n) * waveletArray[freq][n] ); // Divide by 2 so we don't go over double limits later..
 		}
 		// Inverse FFT on data multiplied by wavelet
-		ifftPlan.execute();
+		ifftBuffer.ifft();
         
         // Loop over time of interest
 		for (int t = 0; t < nTimes; t++)
 		{
             int tIndex = int(((t * stepLen) + trimTime)  * Fs); // get index of time of interest
-            std::complex<double> complex = ifftOutput.getAsComplex(tIndex);
+            std::complex<double> complex = ifftBuffer.getAsComplex(tIndex);
             complex *= sqrt(2.0 / nWindow) / double(nfft); // divide by nfft from matlab ifft
                                                            // sqrt(2/nWindow) from ft_specest_mtmconvol.m 
             // Save convOutput for crss later
@@ -185,6 +178,7 @@ void CumulativeTFR::generateWavelet()
 
     // Wavelet
     float freqNormalized = freqStart;
+    FFTWArrayType fftWaveletBuffer(nfft);
     for (int freq = 0; freq < nFreqs; freq++)
     {
         freqNormalized += freqStep;
@@ -200,15 +194,15 @@ void CumulativeTFR::generateWavelet()
 		// Put into fft input array
 		for (int position = 0; position < nfft; position++)
 		{
-            fftInput.set(position, std::complex<double>(cosWave.at(position) * hann.at(position), sinWave.at(position) * hann.at(position)));
+            fftWaveletBuffer.set(position, std::complex<double>(cosWave.at(position) * hann.at(position), sinWave.at(position) * hann.at(position)));
         }
 		
-		fftPlan.execute();
+		fftWaveletBuffer.fftComplex();
 
 		// Save fft output for use later
         for (int i = 0; i < nfft; i++)
         {
-            waveletArray[freq][i] = fftOutput.getAsComplex(i);
+            waveletArray[freq][i] = fftWaveletBuffer.getAsComplex(i);
         }
     }	
 }

--- a/Source/Plugins/CoherenceViewer/CumulativeTFR.h
+++ b/Source/Plugins/CoherenceViewer/CumulativeTFR.h
@@ -31,6 +31,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include <complex>
 
+using FFTWArrayType = FFTWTransformableArrayUsing<FFTW_ESTIMATE>;
+// should we change it to use FFTW_MEASURE? let's discuss
+
 class CumulativeTFR
 {
     // shorten some things
@@ -98,7 +101,7 @@ public:
         int freqStart = 1, double fftSec = 10.0, double alpha = 0);
 
     // Handle a new buffer of data. Preform FFT and create pxxs, pyys.
-    void addTrial(const double* fftIn, int chan);
+    void addTrial(FFTWArrayType& fftBuffer, int chan);
 
     // Function to get coherence between two channels
     void getMeanCoherence(int chanX, int chanY, double* meanDest, int comb);
@@ -125,13 +128,7 @@ private:
 	vector<vector<vector<const std::complex<double>>>> spectrumBuffer;
     vector<vector<std::complex<double>>> waveletArray;
 
-    FFTWArray fftInput;
-    FFTWArray fftOutput;
-    FFTWArray ifftInput;
-    FFTWArray ifftOutput;
-
-    FFTWPlan fftPlan;
-    FFTWPlan ifftPlan;
+    FFTWArrayType ifftBuffer;
 
     // For exponential average
     double alpha;

--- a/Source/Plugins/PhaseCalculator/PhaseCalculator.cpp
+++ b/Source/Plugins/PhaseCalculator/PhaseCalculator.cpp
@@ -166,14 +166,7 @@ namespace PhaseCalculator
 
         // visualization stuff
         hilbertLengthMultiplier = Hilbert::fs * chanInfo.dsFactor / 1000;
-        int visHilbertLength = visHilbertLengthMs * hilbertLengthMultiplier;
-
-        if (visHilbertBuffer.getLength() != visHilbertLength)
-        {
-            visHilbertBuffer.resize(visHilbertLength);
-            visForwardPlan = new FFTWPlan(visHilbertLength, &visHilbertBuffer, FFTW_MEASURE);
-            visBackwardPlan = new FFTWPlan(visHilbertLength, &visHilbertBuffer, FFTW_BACKWARD, FFTW_MEASURE);
-        }
+        visHilbertBuffer.resize(visHilbertLengthMs * hilbertLengthMultiplier);
 
         reverseFilter.setParams(params);
 
@@ -1201,9 +1194,8 @@ namespace PhaseCalculator
             // un-reverse values
             acInfo->visHilbertBuffer.reverseReal(hilbertLength);
 
-            acInfo->visForwardPlan->execute();
-            hilbertManip(&acInfo->visHilbertBuffer, hilbertLength);
-            acInfo->visBackwardPlan->execute();
+            // Hilbert transform!
+            acInfo->visHilbertBuffer.hilbert();
 
             juce::int64 ts;
             ScopedLock phaseBufferLock(visPhaseBufferCS);
@@ -1300,34 +1292,6 @@ namespace PhaseCalculator
                 prediction[s] -= params[p] * pastSamp;
             }
         }
-    }
-
-    void Node::hilbertManip(FFTWArray* fftData, int n)
-    {
-        jassert(fftData->getLength() >= n);
-
-        // Normalize DC and Nyquist, normalize and double positive freqs, and set negative freqs to 0.
-        int lastPosFreq = (n + 1) / 2 - 1;
-        int firstNegFreq = n / 2 + 1;
-        int numPosNegFreqDoubles = lastPosFreq * 2; // sizeof(complex<double>) = 2 * sizeof(double)
-        bool hasNyquist = (n % 2 == 0);
-
-        std::complex<double>* wp = fftData->getComplexPointer();
-
-        // normalize but don't double DC value
-        wp[0] /= n;
-
-        // normalize and double positive frequencies
-        FloatVectorOperations::multiply(reinterpret_cast<double*>(wp + 1), 2.0 / n, numPosNegFreqDoubles);
-
-        if (hasNyquist)
-        {
-            // normalize but don't double Nyquist frequency
-            wp[lastPosFreq + 1] /= n;
-        }
-
-        // set negative frequencies to 0
-        FloatVectorOperations::clear(reinterpret_cast<double*>(wp + firstNegFreq), numPosNegFreqDoubles);
     }
 
     double Node::getScaleFactor(Band band, double lowCut, double highCut)

--- a/Source/Plugins/PhaseCalculator/PhaseCalculator.h
+++ b/Source/Plugins/PhaseCalculator/PhaseCalculator.h
@@ -143,8 +143,7 @@ namespace PhaseCalculator
 
         // for visualization:
         int hilbertLengthMultiplier;
-        FFTWArray visHilbertBuffer;
-        ScopedPointer<FFTWPlan> visForwardPlan, visBackwardPlan;
+        FFTWTransformableArray<> visHilbertBuffer;
         BandpassFilter reverseFilter;
 
         const ChannelInfo& chanInfo;
@@ -335,12 +334,6 @@ namespace PhaseCalculator
         */
         static void arPredict(const ReverseStack& history, int dsOffset, double* prediction,
             const double* params, int samps, int stride, int order);
-
-        /*
-        * hilbertManip: Hilbert transforms data in the frequency domain (including normalization by length of data).
-        * Modifies fftData in place.
-        */
-        static void hilbertManip(FFTWArray* fftData, int n);
 
         // Get the htScaleFactor for the given band's Hilbert transformer,
         // over the range from lowCut and highCut. This is the reciprocal of the geometric

--- a/Source/Plugins/PhaseCalculator/PhaseCalculator.h
+++ b/Source/Plugins/PhaseCalculator/PhaseCalculator.h
@@ -143,7 +143,7 @@ namespace PhaseCalculator
 
         // for visualization:
         int hilbertLengthMultiplier;
-        FFTWTransformableArray<> visHilbertBuffer;
+        FFTWTransformableArray visHilbertBuffer;
         BandpassFilter reverseFilter;
 
         const ChannelInfo& chanInfo;


### PR DESCRIPTION
I thought it would be nice to have an object that combines a `FFTWArray` and an in-place transform plan, so I added some stuff to `FFTWWrapper.h`. That way we don't have to keep track of both the arrays and the plans and keep them the same length, etc. This also makes `FFTWArray` and the new objects copyable and movable, so all the methods should work when they're stored in a Juce array.

I changed `addTrial` to use the data in the input array directly without copying, which I think we were talking about doing at some point? I thought that was the reason the input data was being put into shared `FFTWArray`s.

At the last minute before pushing I noticed line 99 of `CoherenceNode.cpp`, which is probably why we were getting weird coherence results. New data was always being added to the beginning of the data buffer, meaning most of it was never written to and remained uninitialized. Not sure why not doing an in-place transform would change that, but we should see what it looks like now.

See you next week!